### PR TITLE
PlatyPirates-0002-ImageProcessingImportFix

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -296,6 +296,7 @@ public final class Main {
    * Example pipeline.
    */
   public static class MyPipeline implements VisionPipeline {
+
     public Mat returnedImg;
     public int numTargetsDetected;
 
@@ -332,11 +333,11 @@ public final class Main {
         listOfContours.add(contour3);
         listOfContours.add(contour4);
 
-        int border = 15; // border width in pixels
+        int borderWidth = 15; // border width in pixels
         Scalar myBorderColor = new Scalar(255, 0, 0); // RGB values
         //Mat myBorder = new Mat(mat.rows() + border*2, mat.cols() + border*2, mat.depth(), myBorderColor);
         //copyMakeBorder(mat, myBorder, border, border, border, border, BORDER_REPLICATE);
-        drawContours(mat, listOfContours, -1, myBorderColor, border);
+        org.opencv.imgproc.Imgproc.drawContours(mat, listOfContours, -1, myBorderColor, borderWidth);
       }
       numTargetsDetected = detections.length;
       returnedImg = mat;


### PR DESCRIPTION
Fixed the import by adding the import statement directly before the called method.

Needs to be manually merged after the 0001 merge because both are versions of the main branch that fix one error and keep the other.